### PR TITLE
build: fix the comparsion object error with gcc 11

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ FeeFilterRounder filterRounder(::minRelayTxFee);
 struct IteratorComparator
 {
     template<typename I>
-    bool operator()(const I& a, const I& b)
+    bool operator()(const I& a, const I& b) const
     {
         return &(*a) < &(*b);
     }


### PR DESCRIPTION
This commit fixes the error below when trying to compile with GCC 11.3.0.

```
/usr/include/c++/12/bits/stl_tree.h:770:15: error: static assertion failed: comparison object must be invocable as const
  770 |               is_invocable_v<const _Compare&, const _Key&, const _Key&>,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~IteratorComparator::operator()
```